### PR TITLE
Closes VML-4 MarkerClusterGroup plugin

### DIFF
--- a/vaadin-maps-leaflet-flow-demo/src/main/java/software/xdev/vaadin/maps/leaflet/flow/demo/ComplexDemo.java
+++ b/vaadin-maps-leaflet-flow-demo/src/main/java/software/xdev/vaadin/maps/leaflet/flow/demo/ComplexDemo.java
@@ -36,6 +36,7 @@ import software.xdev.vaadin.maps.leaflet.layer.raster.LTileLayer;
 import software.xdev.vaadin.maps.leaflet.layer.raster.LVideoOverlay;
 import software.xdev.vaadin.maps.leaflet.layer.raster.LVideoOverlayOptions;
 import software.xdev.vaadin.maps.leaflet.layer.ui.LMarker;
+import software.xdev.vaadin.maps.leaflet.layer.ui.LMarkerClusterGroup;
 import software.xdev.vaadin.maps.leaflet.layer.ui.LMarkerOptions;
 import software.xdev.vaadin.maps.leaflet.layer.vector.LCircle;
 import software.xdev.vaadin.maps.leaflet.layer.vector.LCircleOptions;
@@ -81,23 +82,23 @@ public class ComplexDemo extends AbstractDemo
 			"https://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png'",
 			19,
 			"&copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors, Tiles style by"
-				+ " <a href=\"https://www.hotosm.org/\" target=\"_blank\">Humanitarian OpenStreetMap Team</a> hosted "
-				+ "by <a href=\"https://openstreetmap.fr/\" target=\"_blank\">OpenStreetMap France</a>"
+			+ " <a href=\"https://www.hotosm.org/\" target=\"_blank\">Humanitarian OpenStreetMap Team</a> hosted "
+			+ "by <a href=\"https://openstreetmap.fr/\" target=\"_blank\">OpenStreetMap France</a>"
 		);
 		final LTileLayer tlTopo = new LTileLayer(
 			this.reg,
 			"https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png",
 			16,
 			"Map data: &copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors, <a "
-				+ "href=\"http://viewfinderpanoramas.org\">SRTM</a> | Map style: &copy; <a href=\"https://opentopomap"
-				+ ".org\">OpenTopoMap</a> (<a href=\"https://creativecommons.org/licenses/by-sa/3.0/\">CC-BY-SA</a>"
+			+ "href=\"http://viewfinderpanoramas.org\">SRTM</a> | Map style: &copy; <a href=\"https://opentopomap"
+			+ ".org\">OpenTopoMap</a> (<a href=\"https://creativecommons.org/licenses/by-sa/3.0/\">CC-BY-SA</a>"
 		);
 		
 		final LDivIcon divIconInfo = new LDivIcon(this.reg, new LDivIconOptions()
 			.withHtml(" <div style=\"white-space:nowrap; padding: 0.5em\">\n" +
-				"<center><b>Welcome to Weiden in der Oberpfalz!</b></center>\n" +
-				"This demo shows you different markers,<br> popups, polygons and other stuff" +
-				"</div>")
+					  "<center><b>Welcome to Weiden in der Oberpfalz!</b></center>\n" +
+					  "This demo shows you different markers,<br> popups, polygons and other stuff" +
+					  "</div>")
 			// Set the icon size to unlimited otherwise the div collapses
 			.withIconSize(new LPoint(this.reg, -1, -1)));
 		final LMarker markerInfo = new LMarker(
@@ -107,16 +108,30 @@ public class ComplexDemo extends AbstractDemo
 		
 		@SuppressWarnings("checkstyle:LineLength")
 		final LIcon iconXDEV = new LIcon(this.reg, new LIconOptions()
-			.withIconUrl("data:image/svg+xml;utf8,<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"1000\" height=\"200\" viewBox=\"0 0 18300 4500\" style=\"background-color:rgba(180,180,180,0.7)\">"+
-				  "<defs>\n"+
-				    "<style>\n"+
-				      ".fil0{fill:%23d71e23}\n"+
-				    "</style>\n"+
-				  "</defs>\n"+
-				  "<g>\n"+
-				    "<path class=\"fil0\" d=\"M9763 10965h-920l-17-6-1503-588-1506 588-11 4-13 2-1562 148-1102 105 1064-369 2311-801-1638-633-683-263h1609l16 6 1515 588 1521-588 10-4 9-1 1388-211 1177-178-1131 441-2177 849 1675 647 682 264zM25514 9520l-1909 1442-22 17h-693l-23-19-1765-1440-285-233h907l22 17 1490 1178 1395-1177 23-19h1171zM20426 10961h-4015V9260h4126l-1 127-1 99v126h-112l-3041-3 2 322 3038 3h110l2 124 1 83 2 128h-3146v352l3035-6h112v346z\" transform=\"translate(-5400 -7700)\"/>\n"+
-				    "<path class=\"fil0\" d=\"M10994 9275h2026a12150 12150 0 0 1 1368 73c292 35 559 83 798 143h1c290 73 510 158 659 254 165 106 248 229 248 368 0 134-85 254-254 359-151 94-375 180-672 256-292 76-618 132-977 170-359 37-751 56-1174 56h-2102V9275h79zm917 1354h1106c300 0 574-14 822-41 247-27 469-67 665-121h1a2470 2470 0 0 0 277-96c176-79 264-164 264-256 0-60-39-118-117-173-92-66-234-125-425-178-197-55-418-96-665-123-248-27-522-41-822-41h-1106v1029z\" transform=\"translate(-5400 -7700)\"/>\n"+
-				  "</g>\n"+
+			.withIconUrl(
+				"data:image/svg+xml;utf8,<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"1000\" height=\"200\" "
+				+ "viewBox=\"0 0 18300 4500\" style=\"background-color:rgba(180,180,180,0.7)\">"
+				+
+				"<defs>\n" +
+				"<style>\n" +
+				".fil0{fill:%23d71e23}\n" +
+				"</style>\n" +
+				"</defs>\n" +
+				"<g>\n" +
+				"<path class=\"fil0\" d=\"M9763 10965h-920l-17-6-1503-588-1506 588-11 4-13 2-1562 148-1102 105 "
+				+ "1064-369 2311-801-1638-633-683-263h1609l16 6 1515 588 1521-588 10-4 9-1 1388-211 1177-178-1131 "
+				+ "441-2177 849 1675 647 682 264zM25514 9520l-1909 1442-22 17h-693l-23-19-1765-1440-285-233h907l22 17 "
+				+ "1490 1178 1395-1177 23-19h1171zM20426 10961h-4015V9260h4126l-1 127-1 99v126h-112l-3041-3 2 322 3038"
+				+ " 3h110l2 124 1 83 2 128h-3146v352l3035-6h112v346z\" transform=\"translate(-5400 -7700)\"/>\n"
+				+
+				"<path class=\"fil0\" d=\"M10994 9275h2026a12150 12150 0 0 1 1368 73c292 35 559 83 798 143h1c290 73 "
+				+ "510 158 659 254 165 106 248 229 248 368 0 134-85 254-254 359-151 94-375 180-672 256-292 76-618 "
+				+ "132-977 170-359 37-751 56-1174 56h-2102V9275h79zm917 1354h1106c300 0 574-14 822-41 247-27 469-67 "
+				+ "665-121h1a2470 2470 0 0 0 277-96c176-79 264-164 264-256 "
+				+ "0-60-39-118-117-173-92-66-234-125-425-178-197-55-418-96-665-123-248-27-522-41-822-41h-1106v1029z\" "
+				+ "transform=\"translate(-5400 -7700)\"/>\n"
+				+
+				"</g>\n" +
 				"</svg>")
 			.withIconSize(new LPoint(this.reg, 125, 25)));
 		
@@ -163,15 +178,15 @@ public class ComplexDemo extends AbstractDemo
 			.addLayer(markerXDEV)
 			.addLayer(polygonNOC)
 			.addLayer(markerInfo);
-		final LLayerGroup lLayerGroupFood =
-			new LLayerGroup(this.reg, markerPizza, markerSchnitzel, circleFood, polylineToSchnitzel);
 		
+		final LMarkerClusterGroup lMarkerClusterGroup = new LMarkerClusterGroup(this.reg);
+		lMarkerClusterGroup.addLayers(markerPizza, markerSchnitzel, circleFood, polylineToSchnitzel);
 		// Add default layers
 		this.map
 			.addLayer(tlOSM)
 			.addLayer(lLayerGroupPlaces);
 		
-		this.addControls(tlOSM, tlOSMHOT, tlTopo, lLayerGroupPlaces, lLayerGroupFood);
+		this.addControls(tlOSM, tlOSMHOT, tlTopo, lLayerGroupPlaces, lMarkerClusterGroup);
 		
 		this.hlButtons.setWidthFull();
 		this.add(this.hlButtons);
@@ -240,20 +255,20 @@ public class ComplexDemo extends AbstractDemo
 		this.map.on(
 			"locationerror",
 			"e => alert('Failed to locate: ' "
-				+ "+ '\\nCode: ' + e.code "
-				+ "+ '\\nMessage: ' + e.message"
-				+ ")");
+			+ "+ '\\nCode: ' + e.code "
+			+ "+ '\\nMessage: ' + e.message"
+			+ ")");
 		this.map.on(
 			"locationfound",
 			"e => alert('Location successful: '"
-				+ "+ '\\nLocation: ' + e.latlng "
-				+ "+ '\\nBounds: ' + e.bounds?.getNorthWest() + ' ' + e.bounds?.getSouthEast() "
-				+ "+ '\\nAccuracy(m): ' + e.accuracy "
-				+ "+ '\\nAltitude(m): ' + e.altitude "
-				+ "+ '\\nAltitudeAccuracy(m): ' + e.altitudeAccuracy "
-				+ "+ '\\nHeading: ' + e.heading"
-				+ "+ '\\nSpeed: ' + e.speed "
-				+ ")");
+			+ "+ '\\nLocation: ' + e.latlng "
+			+ "+ '\\nBounds: ' + e.bounds?.getNorthWest() + ' ' + e.bounds?.getSouthEast() "
+			+ "+ '\\nAccuracy(m): ' + e.accuracy "
+			+ "+ '\\nAltitude(m): ' + e.altitude "
+			+ "+ '\\nAltitudeAccuracy(m): ' + e.altitudeAccuracy "
+			+ "+ '\\nHeading: ' + e.heading"
+			+ "+ '\\nSpeed: ' + e.speed "
+			+ ")");
 		this.hlButtons.add(new Button("Locate", ev -> this.map.locate(new LMapLocateOptions().withSetView(true))));
 	}
 	
@@ -346,11 +361,11 @@ public class ComplexDemo extends AbstractDemo
 			));
 		final String imageLink =
 			"https://upload.wikimedia.org/wikipedia/commons/thumb/f/f9/Building_and_ship_comparison_to_the_Pentagon2"
-				+ ".svg/260px-Building_and_ship_comparison_to_the_Pentagon2.svg.png";
+			+ ".svg/260px-Building_and_ship_comparison_to_the_Pentagon2.svg.png";
 		pentagon.bindPopup("<a href='https://en.wikipedia.org/wiki/The_Pentagon' target='_blank'>"
-			+ "<center><b>The Pentagon</b></center><br>"
-			+ "<img style='width:12em' src='" + imageLink + "'>"
-			+ "</a>");
+						   + "<center><b>The Pentagon</b></center><br>"
+						   + "<img style='width:12em' src='" + imageLink + "'>"
+						   + "</a>");
 		this.hlButtons.add(this.createToggleButton(
 			"Show complex polygon",
 			"Hide complex polygon",

--- a/vaadin-maps-leaflet-flow/src/main/java/software/xdev/vaadin/maps/leaflet/MapContainer.java
+++ b/vaadin-maps-leaflet-flow/src/main/java/software/xdev/vaadin/maps/leaflet/MapContainer.java
@@ -38,10 +38,17 @@ import software.xdev.vaadin.maps.leaflet.registry.LComponentManagementRegistry;
 /**
  * Component that contains a {@link LMap} and all required client side dependencies for Vaadin.
  */
+
 @NpmPackage(value = "leaflet", version = "1.9.4")
-@Tag("leaflet-map")
-@JsModule("leaflet/dist/leaflet.js")
+@NpmPackage(value = "leaflet.markercluster", version = "1.4.1")
+// We cannot import Leaflet and the plugins using many @JsModule annotations, because Vaadin has a bug that does not
+// guarantee that the imports will be in the same order as defined with @JsModule: https://github.com/vaadin/flow/issues/15825
+@JsModule("./leaflet/import-leaflet-with-plugins.js")
+
 @CssImport("leaflet/dist/leaflet.css")
+@CssImport("leaflet.markercluster/dist/MarkerCluster.Default.css")
+@CssImport("leaflet.markercluster/dist/MarkerCluster.css")
+@Tag("leaflet-map")
 public class MapContainer extends Composite<Div> implements HasSize, HasStyle, HasComponents, HasText
 {
 	private final LMap lMap;

--- a/vaadin-maps-leaflet-flow/src/main/java/software/xdev/vaadin/maps/leaflet/layer/LLayerGroup.java
+++ b/vaadin-maps-leaflet-flow/src/main/java/software/xdev/vaadin/maps/leaflet/layer/LLayerGroup.java
@@ -27,25 +27,42 @@ import software.xdev.vaadin.maps.leaflet.registry.LComponentManagementRegistry;
  */
 public class LLayerGroup extends LLayer<LLayerGroup> implements LHasSetZIndex<LLayerGroup>
 {
-	public LLayerGroup(
+	protected LLayerGroup(
+		final String  jsConstructorCallExpression,
 		final LComponentManagementRegistry compReg,
 		final LLayer<?>[] layers,
 		final LLayerOptions<?>[] options)
 	{
 		super(
 			compReg,
-			"L.layerGroup("
-				+ (layers != null
+			jsConstructorCallExpression + "("
+			+ (layers != null && layers.length > 0
 				? "[" + Stream.of(layers)
 				.map(LLayer::clientComponentJsAccessor)
 				.collect(Collectors.joining(",")) + "]"
 				: "")
-				+ (options != null
+			+ (options != null
 				? ", [" + Stream.of(options)
 				.map(compReg::writeOptionsOrEmptyObject)
 				.collect(Collectors.joining(",")) + "]"
 				: "")
-				+ ")");
+			+ ")");
+	}
+	
+	protected LLayerGroup(
+		final String  jsConstructorCallExpression,
+		final LComponentManagementRegistry compReg,
+		final LLayer<?>... layers)
+	{
+		this(jsConstructorCallExpression, compReg, layers, null);
+	}
+	
+	public LLayerGroup(
+		final LComponentManagementRegistry compReg,
+		final LLayer<?>[] layers,
+		final LLayerOptions<?>[] options)
+	{
+		this("L.layerGroup", compReg, layers, options);
 	}
 	
 	public LLayerGroup(

--- a/vaadin-maps-leaflet-flow/src/main/java/software/xdev/vaadin/maps/leaflet/layer/ui/LMarkerClusterGroup.java
+++ b/vaadin-maps-leaflet-flow/src/main/java/software/xdev/vaadin/maps/leaflet/layer/ui/LMarkerClusterGroup.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2019 XDEV Software (https://xdev.software)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package software.xdev.vaadin.maps.leaflet.layer.ui;
+
+import java.util.Arrays;
+
+import software.xdev.vaadin.maps.leaflet.layer.LLayer;
+import software.xdev.vaadin.maps.leaflet.layer.LLayerGroup;
+import software.xdev.vaadin.maps.leaflet.registry.LComponentManagementRegistry;
+
+
+/**
+ * <p>
+ * Leaflet plugin Marker Cluster, see <a href="https://github.com/Leaflet/Leaflet.markercluster">Marker cluster Leaflet
+ * plugin</a>
+ * </p>
+ * <p>
+ * LMarkerClusterGroup does not take layers as parameters, please use {@link #addLayers(LLayer[])} method.
+ * </p>
+ */
+public class LMarkerClusterGroup extends LLayerGroup
+{
+	public LMarkerClusterGroup(final LComponentManagementRegistry compReg)
+	{
+		super("L.markerClusterGroup", compReg);
+	}
+	
+	/**
+	 * To add markers to this cluster group
+	 *
+	 * @param layers The LLayer to be added to this cluster group
+	 */
+	public LLayerGroup addLayers(final LLayer<?>... layers)
+	{
+		Arrays.stream(layers).forEach(this::addLayer);
+		return this.self();
+	}
+}

--- a/vaadin-maps-leaflet-flow/src/main/resources/META-INF/resources/frontend/leaflet/import-leaflet-with-plugins.js
+++ b/vaadin-maps-leaflet-flow/src/main/resources/META-INF/resources/frontend/leaflet/import-leaflet-with-plugins.js
@@ -1,0 +1,4 @@
+// We cannot import Leaftlet and the plugins using many @JsModule annotations, because Vaadin has a bug that does not
+// guarantee that the imports will be in the same order as defined with @JsModule: https://github.com/vaadin/flow/issues/15825
+import 'leaflet/dist/leaflet.js';
+import 'leaflet.markercluster/dist/leaflet.markercluster.js';


### PR DESCRIPTION
- Added the NPM module of MarkerClusterGroup
- Created the Java class that inherits from the existing LLayerGroup one and
- Added the needed Javascript fragment for MarkerClusterGroup
- Slightly changed that demo View to show the cluster of markers about Foods 

To try it, go to the Complex demo and select the Food layer and try to zoom out:

https://github.com/user-attachments/assets/93c6f2f7-3406-4068-bd9c-23fd8bfa601f

For the moment we accept that the checkstyle is not passing.
